### PR TITLE
chore: supply-chain hardening — add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Repo already has strong supply-chain posture (packageManager pinned, engines, .nvmrc, .npmrc with audit/engine-strict/save-exact/fund, pnpm-workspace minimumReleaseAge). This PR just adds .github/dependabot.yml with 7-day cooldown to align update bot with install-time release-age gate.